### PR TITLE
Add --hex-blob for safe blob backups

### DIFF
--- a/MySQLBackup.Application/Backup/MySQLDumpProcess.cs
+++ b/MySQLBackup.Application/Backup/MySQLDumpProcess.cs
@@ -41,7 +41,7 @@ namespace MySQLBackup.Application.Backup
                     {
                         dumpOptions += "--databases ";
                     };
-                    dumpOptions += string.Format(@"""{0}"" -u{1} -p{2} -h{3} -P{4} --add-drop-database --add-drop-table --add-locks --comments --create-options --dump-date --lock-tables"
+                    dumpOptions += string.Format(@"""{0}"" -u{1} -p{2} -h{3} -P{4} --add-drop-database --add-drop-table --add-locks --comments --create-options --dump-date --lock-tables --hex-blob"
                        , dbInfo.DatabaseName
                        , dbInfo.User
                        , dbInfo.Password


### PR DESCRIPTION
Without `--hex-blob`, `mysqldump` exports `blob` and `longblob` fields as UTF-8 text strings. These can't always be restored properly. Using `--hex-blob` [resolves this](https://stackoverflow.com/a/31715391/81949).

The downside is that backup files with blob data grow larger. IMO that's worth it; reliability of backups is more important than the space efficiency.